### PR TITLE
fix(manifest): include news/*.rst for check-manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ recursive-include requirements *.in *.txt
 recursive-include src *.py *.html *.po *.mo
 recursive-include tests *.py *.html
 recursive-include docs *.md
+recursive-include news *.rst


### PR DESCRIPTION
## Summary
Add \ecursive-include news *.rst\ so pre-commit.ci \check-manifest\ passes on autoupdate PRs with towncrier fragments (e.g. #657).

## Test plan
- [ ] \check-manifest\ passes locally and on pre-commit.ci
